### PR TITLE
fix: points 2,3 as in email

### DIFF
--- a/app/faculty/page.tsx
+++ b/app/faculty/page.tsx
@@ -11,7 +11,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { MapPin, CalendarDays, Clock } from "lucide-react";
 import { facultyData } from "@/data/faculty";
 import { useState } from "react";
 
@@ -40,10 +39,14 @@ export default function ProgramsPage() {
         </h2>
         <Tabs defaultValue="piano" className="w-full">
           <div className="flex justify-center mb-8">
-            <TabsList className="max-w-full">
+            <TabsList className="max-w-full bg-rose-50 dark:bg-rose-900/20 px-5 py-7 shadow-md">
               <div className="flex items-center overflow-x-auto">
                 {facultyData.faculty.categories.map((category) => (
-                  <TabsTrigger key={category.name} value={category.name}>
+                  <TabsTrigger
+                    key={category.name}
+                    value={category.name}
+                    className="px-6 text-lg font-semibold"
+                  >
                     {category.label}
                   </TabsTrigger>
                 ))}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -29,6 +29,54 @@ export default function NewsPage() {
         </div>
       </section>
 
+      {/* Events Section */}
+      <section className="bg-slate-50 dark:bg-slate-900 py-12 md:py-16">
+        <h2 className="text-3xl font-bold tracking-tighter text-center mb-8 text-foreground">
+          {newsData.events.title}
+        </h2>
+        <div className="container">
+          <div className="grid gap-8 sm:grid-cols-2">
+            {newsData.events.items.map((event, index) => (
+              <div
+                key={index}
+                className="bg-white dark:bg-slate-800 rounded-lg overflow-hidden border dark:border-slate-700 shadow-sm hover:shadow-md transition-shadow"
+              >
+                <div className="relative h-[300px]">
+                  <Image
+                    src={event.image || "/placeholder.svg"}
+                    alt={event.name}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="p-6">
+                  <h3 className="text-xl font-semibold">{event.name}</h3>
+                  <div className="flex items-center gap-2 mb-2">
+                    <MapPin className="h-4 w-4 text-rose-500" />
+                    <p className="text-base text-rose-500 dark:text-rose-400">
+                      {event.location}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <CalendarDays className="h-4 w-4 text-rose-500" />
+                    <p className="text-base text-muted-foreground">
+                      {event.date}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 mb-4">
+                    <Clock className="h-4 w-4 text-rose-500" />
+                    <p className="text-base text-muted-foreground">
+                      {event.time}
+                    </p>
+                  </div>
+                  <p className="text-base text-muted-foreground">{event.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* Latest News Section */}
       <section className="container py-12 md:py-16">
         <h2 className="text-3xl font-bold tracking-tighter mb-8 text-foreground">
@@ -60,6 +108,7 @@ export default function NewsPage() {
               </div>
             </div>
 
+            {/* Awards Section */}
             {item.achievements && (
               <div className="space-y-12">
                 {Object.entries(item.achievements).map(
@@ -135,54 +184,6 @@ export default function NewsPage() {
             )}
           </div>
         ))}
-      </section>
-
-      {/* Events Section */}
-      <section className="bg-slate-50 dark:bg-slate-900 py-12 md:py-16">
-        <h2 className="text-3xl font-bold tracking-tighter text-center mb-8 text-foreground">
-          {newsData.events.title}
-        </h2>
-        <div className="container">
-          <div className="grid gap-8 sm:grid-cols-2">
-            {newsData.events.items.map((event, index) => (
-              <div
-                key={index}
-                className="bg-white dark:bg-slate-800 rounded-lg overflow-hidden border dark:border-slate-700 shadow-sm hover:shadow-md transition-shadow"
-              >
-                <div className="relative h-[300px]">
-                  <Image
-                    src={event.image || "/placeholder.svg"}
-                    alt={event.name}
-                    fill
-                    className="object-cover"
-                  />
-                </div>
-                <div className="p-6">
-                  <h3 className="text-xl font-semibold">{event.name}</h3>
-                  <div className="flex items-center gap-2 mb-2">
-                    <MapPin className="h-4 w-4 text-rose-500" />
-                    <p className="text-base text-rose-500 dark:text-rose-400">
-                      {event.location}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2 mb-2">
-                    <CalendarDays className="h-4 w-4 text-rose-500" />
-                    <p className="text-base text-muted-foreground">
-                      {event.date}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2 mb-4">
-                    <Clock className="h-4 w-4 text-rose-500" />
-                    <p className="text-base text-muted-foreground">
-                      {event.time}
-                    </p>
-                  </div>
-                  <p className="text-base text-muted-foreground">{event.description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
- Faculty page - I was wondering where Bonnie was and then realized I had to click on the flute button.  I’m worried some of the visitors will miss the instrument tabs and think we only teach piano.  Maybe we should make the buttons bigger?  Or maybe just list all the teachers on the page?
- News and Events – Can we include Sunny Kim’s students under piano?  Sorry I should have made that clearer.  Also can we swap the order and place upcoming events on top and student/teacher awards next?  Since there are so many student awards I worry people might not scroll to the bottom to see the events lol.  I love the way you designed how to display the awards